### PR TITLE
Add support for aws lambda protobuf workaround

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2132,6 +2132,53 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "aws-sdk": {
+      "version": "2.713.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.713.0.tgz",
+      "integrity": "sha512-axR1eOVn134KXJc1IT+Au2TXcK6oswY+4nvGe5GfU3pXeehhe0xNeP9Bw9yF36TRBxuvu4IJ2hRHDKma05smgA==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "events": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+        },
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "url": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -2340,8 +2387,7 @@
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-      "dev": true
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -2684,7 +2730,6 @@
       "version": "4.9.2",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
       "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-      "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -6366,8 +6411,7 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "iferr": {
       "version": "0.1.5",
@@ -6781,8 +6825,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isbinaryfile": {
       "version": "4.0.4",
@@ -8513,6 +8556,11 @@
           }
         }
       }
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -10402,8 +10450,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -11403,8 +11450,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "saxes": {
       "version": "3.1.11",
@@ -13479,6 +13525,20 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "dependencies": {
     "antd": "^4.1.3",
+    "aws-sdk": "^2.713.0",
     "immer": "^5.3.6",
     "node-fetch": "^2.6.0",
     "protobufjs": "^6.8.8",

--- a/src/core/http_client/client.ts
+++ b/src/core/http_client/client.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
+import * as aws from 'aws-sdk';
 import { RequestDescriptor } from './request';
 import { ProtoCtx } from '../protobuf/protobuf';
 import { convertHeaders, unconvertHeaders } from './headers';
 import { ResponseBodyValue, ResponseDescriptor, ResponseBodyType } from './response';
-import fetch, { Response } from 'node-fetch';
+import fetch, { Response, Headers } from 'node-fetch';
 import { deserializeProtobuf } from '../protobuf/deserializer';
 
 const CONTENT_TYPE_JSON = 'application/json';
@@ -15,12 +16,38 @@ export async function makeRequest(request: RequestDescriptor, protoCtx: ProtoCtx
   const headers = convertHeaders(request.headers);
 
   const sTime = Date.now();
-  const resp = await fetch(url, { method, body, headers });
+
+  const match = /https:\/\/lambda\/([a-zA-z0-9\-]+)(?:\/([a-z\-0-9]+))?/.exec(url);
+
+  let response;
+  if (match) {
+    const [, lambdaName, region] = match;
+
+    const lambda = new aws.Lambda({ region: region ?? 'us-east-2' });
+
+    const buf = body ? Buffer.from(body) : undefined;
+
+    const resp = await lambda
+      .invoke({
+        FunctionName: lambdaName,
+        Payload: buf,
+      })
+      .promise()
+      .catch(err => {
+        console.log({ err });
+        throw err;
+      });
+    const headers = new Headers();
+    headers.append('content-type', CONTENT_TYPE_JSON);
+    response = new Response(resp.Payload as Buffer, { headers });
+  } else {
+    response = await fetch(url, { method, body, headers });
+  }
   const eTime = Date.now();
 
   const dt = eTime - sTime;
 
-  return translateResponse(resp, request, protoCtx, dt);
+  return translateResponse(response, request, protoCtx, dt);
 }
 
 async function translateResponse(
@@ -38,12 +65,20 @@ async function translateResponse(
   let responseBodyValue: ResponseBodyValue = undefined;
   let warning: string | undefined = undefined;
 
-  const buf = new Uint8Array(await response.arrayBuffer());
+  let buf = new Uint8Array(await response.arrayBuffer());
+
+  if (saidContentType === CONTENT_TYPE_JSON && buf.length >= 2) {
+    const quoteByte = '"'.charCodeAt(0);
+    if (buf[0] === quoteByte && buf[buf.length - 1] == quoteByte) {
+      responseBodyType = 'base64-protobuf-in-json-string';
+      buf = decodeBase64ProtobufInJsonString(buf);
+    }
+  }
 
   if (buf.length === 0) {
     responseBodyType = 'empty';
     responseBodyValue = undefined;
-  } else if (saidContentType === CONTENT_TYPE_JSON) {
+  } else if (saidContentType === CONTENT_TYPE_JSON && responseBodyType !== 'base64-protobuf-in-json-string') {
     responseBodyType = 'json';
     responseBodyValue = toJson(buf);
   } else if (saidContentType?.includes(CONTENT_TYPE_HTML)) {
@@ -97,4 +132,11 @@ function toJson(buf: Uint8Array): string {
   } catch (err) {
     throw new Error('Error occurred while parsing json:\n' + err.message + '\nGiven JSON:\n' + str);
   }
+}
+
+function decodeBase64ProtobufInJsonString(arr: Uint8Array): Buffer {
+  const buf = Buffer.from(arr);
+  const unquoted = buf.slice(1, buf.length - 1);
+  const base64encoded = unquoted.toString('utf8');
+  return Buffer.from(base64encoded, 'base64');
 }

--- a/src/core/http_client/response.ts
+++ b/src/core/http_client/response.ts
@@ -1,7 +1,7 @@
 import { MessageValue } from '../protobuf/protobuf';
 
 // string for json and html - deserves better support, but this will do for now.
-export type ResponseBodyType = 'empty' | 'protobuf' | 'json' | 'html' | 'unknown';
+export type ResponseBodyType = 'empty' | 'protobuf' | 'json' | 'base64-protobuf-in-json-string' | 'html' | 'unknown';
 export type ResponseBodyValue = undefined | MessageValue | string;
 
 export interface ResponseBody {


### PR DESCRIPTION
This commit adds support for specially formatted url:
`https://lambda/<lambda-name>[/<region>]`
If you specify it in this format, Protoman
invokes a lambda, the request to it
will be base64 encoded and enquoted and
responses will be unquoted and base64-decoded.